### PR TITLE
Fix 获取 我的礼包 流量包 activeCode为73或者2534 的 grep 匹配问题

### DIFF
--- a/CnUnicom.sh
+++ b/CnUnicom.sh
@@ -256,7 +256,7 @@ function liulactive() {
         # 我的礼包-流量包-1G日包对应activeCode为73或者2534,当参数mygiftbag存在时运行: liulactive@d@ff80808166c5ee6701676ce21fd14716@13012341234@mygiftbag
         if [[ "$mygiftbag" != "" ]]; then
             curl -m 10 -X POST -sA "$UA"  -b $workdir/cookie --data "typeScreenCondition=2&category=FFLOWPACKET&pageSign=1&CALLBACKURL=https%3A%2F%2Fm.client.10010.com%2FmyPrizeForActivity%2Fquerywinninglist.htm" http://m.client.10010.com/myPrizeForActivity/mygiftbag.htm >$workdir/libaollactive.log
-            mygiftbaglist=($(cat $workdir/libaollactive.log | grep -oE "(73|2534)','[a-zA-Z0-9]+" | sed "s/','/@/g" | tr "\n" " "))
+            mygiftbaglist=($(cat $workdir/libaollactive.log | grep -oE "'(73|2534)','[a-zA-Z0-9]+" | sed -e "s/','/@/g" -e "s/^'//g"  | tr "\n" " "))
             for ((j = 0; j < ${#mygiftbaglist[*]}; j++)); do
                 curl -m 10 -X POST -sA "$UA"  -b $workdir/cookie --data "activeCode=${mygiftbaglist[j]%@*}&prizeRecordID=${mygiftbaglist[j]#*@}&userNumber=${username}" http://m.client.10010.com/myPrizeForActivity/queryPrizeDetails.htm >$workdir/libaollactive.log2
                 cat $workdir/libaollactive.log2 | grep -A 15 "奖品状态" | grep -qE "(未激活|激活失败)" || continue


### PR DESCRIPTION
有时候会匹配错误，比如我的这个： 下面 xxxx 是我手机号码 所以隐藏了。

> cat $workdir/libaollactive.log | grep -E "(73|2534)','[a-zA-Z0-9]+"  | tail -n 1
>				   onclick="toDetailPage('245','yh1202102270741311762xxxx8173','1762xxxxx81');">
